### PR TITLE
feat: get text from quill

### DIFF
--- a/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
+++ b/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
@@ -45,6 +45,10 @@ export class MudQuillInterop {
         this.toolbarRef = toolbarRef;
     }
 
+    getText = () => {
+        return this.quill.getText();
+    };
+
     getHtml = () => {
         return this.quill.root.innerHTML;
     };
@@ -69,5 +73,6 @@ export class MudQuillInterop {
      */
     textChangedHandler = (delta, oldDelta, source) => {
         this.dotNetRef.invokeMethodAsync('HandleHtmlContentChanged', this.getHtml());
+        this.dotNetRef.invokeMethodAsync('HandleTextContentChanged', this.getText());
     };
 }


### PR DESCRIPTION
I was surprised that MudBlazor doesn't have a rich text editor component, so I did a little searching and found your great project! It fits right in with the rest of the MudBlazor theme.

This is a small PR to add a feature that I need: to get the text content from quill. Rather than write some code on my side of the equation to solve this problem, I thought it might benefit other users of your component as well.

This PR adds:

The public methods `GetHtml` and `GetText` to the `MudHtmlEditor` API; thus, when using a `@ref` reference to the component, one can call either of these methods to get the HTML or text content of the quill editor upon demand.

I followed the approach you took with `Html` to make the `Text` parameter bindable.

I'm happy to hear any criticism or feedback.