### PR TITLE
feat: add support for uploading images via blazor method or controller.

### DIFF
--- a/samples/BlazorServer/BlazorServer.csproj
+++ b/samples/BlazorServer/BlazorServer.csproj
@@ -14,4 +14,8 @@
     <ProjectReference Include="..\..\src\Tizzani.MudBlazor.HtmlEditor\Tizzani.MudBlazor.HtmlEditor.csproj" />
   </ItemGroup>
 
+	<ItemGroup>
+		<Folder Include="wwwroot\images\" />
+	</ItemGroup>
+
 </Project>

--- a/samples/BlazorServer/Controllers/FileController.cs
+++ b/samples/BlazorServer/Controllers/FileController.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace BlazorServer.Controllers
+{
+    [Route("[Controller]/[Action]")]
+    public class FileController : Controller
+    {
+        private readonly IConfiguration _config;
+        public FileController(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Upload(List<IFormFile> files)
+        {
+            var file = files[0];
+            var root = _config.GetValue<string>(WebHostDefaults.ContentRootKey) ?? "";
+            var path = Path.Combine(root, $"wwwroot{Path.DirectorySeparatorChar}images", file.FileName);
+            FileStream filestream = new FileStream(path, FileMode.Create, FileAccess.Write);
+            await file.CopyToAsync(filestream);
+            filestream.Close();
+
+            return Content($"images/{file.FileName}");
+        }
+    }
+}

--- a/samples/BlazorServer/Pages/EditorView.razor
+++ b/samples/BlazorServer/Pages/EditorView.razor
@@ -1,4 +1,6 @@
-﻿<MudStack Justify="Justify.FlexEnd" Row="true">
+﻿@inject IConfiguration _config;
+
+<MudStack Justify="Justify.FlexEnd" Row="true">
     <MudButton OnClick="OnCancel" Size="Size.Small">Cancel</MudButton>
     <MudButton OnClick="Reset" Size="Size.Small">Reset</MudButton>
     <MudButton Color="Color.Primary" OnClick="SaveChanges" Size="Size.Small" StartIcon="@Icons.Material.Filled.Save" Variant="Variant.Filled">Save Changes</MudButton>
@@ -32,5 +34,17 @@
     private async Task SaveChanges()
     {
         await OnSave.InvokeAsync(_html);
+    }
+
+    // Upload the image into the wwwroot/images folder for demonstration
+    private async Task<string> ImageUploadHandler(string imageName, string imageContentType, Stream imageStream)
+    {
+        var root = _config.GetValue<string>(WebHostDefaults.ContentRootKey) ?? "";
+        var path = Path.Combine(root, $"wwwroot{Path.DirectorySeparatorChar}images", imageName);
+        FileStream filestream = new FileStream(path, FileMode.Create, FileAccess.Write);
+        await imageStream.CopyToAsync(filestream);
+        filestream.Close();
+
+        return $"images/{imageName}";
     }
 }

--- a/samples/BlazorServer/Program.cs
+++ b/samples/BlazorServer/Program.cs
@@ -23,6 +23,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.MapControllers();
 app.MapBlazorHub();
 app.MapFallbackToPage("/_Host");
 

--- a/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
+++ b/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
@@ -1,4 +1,5 @@
 var Embed = Quill.import('blots/block/embed');
+const Delta = Quill.import('delta');
 
 class Divider extends Embed {
     static create(value) {
@@ -16,18 +17,34 @@ try {
     Quill.register('modules/blotFormatter', QuillBlotFormatter.default);
 } catch { }    
 
-export function createQuillInterop(dotNetRef, editorRef, toolbarRef, placeholder) {
-    var quill = new Quill(editorRef, {
+
+export function createQuillInterop(dotNetRef, editorRef, toolbarRef, settings) {
+    var interop = new MudQuillInterop(dotNetRef, editorRef, toolbarRef, settings);
+
+    var properties = {
         modules: {
             toolbar: {
                 container: toolbarRef
             },
-            blotFormatter: {}
+            blotFormatter: {},
+            uploader: {
+                mimetypes: settings.allowedImageMimeTypes
+            }
         },
-        placeholder: placeholder,
+        placeholder: settings.placeholder,
         theme: 'snow'
-    });
-    return new MudQuillInterop(dotNetRef, quill, editorRef, toolbarRef);
+    };
+
+    // Use custom handler if specified
+    if (settings.blazorImageUpload || settings.imageUploadUrl) {
+        properties.modules.uploader.handler = interop.uploadImageHandler;
+    }
+
+    var quill = new Quill(editorRef, properties);
+
+    interop.addQuill(quill);
+
+    return interop;
 }
 
 export class MudQuillInterop {
@@ -35,14 +52,22 @@ export class MudQuillInterop {
      * @param {Quill} quill
      * @param {Element} editorRef
      * @param {Element} toolbarRef
+     * @param {object} toolbarRef
      */
-    constructor(dotNetRef, quill, editorRef, toolbarRef) {
-        quill.getModule('toolbar').addHandler('hr', this.insertDividerHandler);
-        quill.on('text-change', this.textChangedHandler);
+    constructor(dotNetRef, editorRef, toolbarRef, settings) {
         this.dotNetRef = dotNetRef;
-        this.quill = quill;
+        this.quill;
         this.editorRef = editorRef;
         this.toolbarRef = toolbarRef;
+        this.blazorImageUpload = settings.blazorImageUpload;
+        this.imageBytes = {};
+        this.imageUploadUrl = settings.imageUploadUrl;
+    }
+
+    addQuill = (quill) => {
+        quill.getModule('toolbar').addHandler('hr', this.insertDividerHandler);
+        quill.on('text-change', this.textChangedHandler);
+        this.quill = quill;
     }
 
     getHtml = () => {
@@ -70,4 +95,65 @@ export class MudQuillInterop {
     textChangedHandler = (delta, oldDelta, source) => {
         this.dotNetRef.invokeMethodAsync('HandleHtmlContentChanged', this.getHtml());
     };
+
+    // Get imageBytes by filename
+    getImageBytes = (key) => {
+        return this.imageBytes[key];
+    }
+
+    // Read file and upload it via the blazor or controller method
+    upload(file) {
+        const fileReader = new FileReader();
+        return new Promise((resolve, reject) => {
+            fileReader.addEventListener("load", () => {
+                // Pass file via DotNetInterop
+                if (this.blazorImageUpload) {
+                    this.imageBytes[file.name] = new Uint8Array(fileReader.result);
+                    this.dotNetRef.invokeMethodAsync("SaveImage", file.name, file.type, file.size).then(url => resolve({name: file.name, url: url }));
+                }
+                // Upload to API endpoint
+                else if (this.imageUploadUrl) {
+                    const formData = new FormData();
+                    formData.append("files", file);
+
+                    fetch(this.imageUploadUrl, {
+                        method: "POST",
+                        headers: {},
+                        body: formData
+                    })
+                    .then(response => {
+                        if (response.status === 200) {
+                            response.text().then(url =>
+                                resolve({ name: file.name, url: url })
+                            );
+                        }
+                        else {
+                            reject("Error uploading image to " + this.imageUploadUrl);
+                        }
+                    });
+                }
+            });
+
+            if (file) {
+                fileReader.readAsArrayBuffer(file);
+            } else {
+                reject("No file selected");
+            }
+        });
+    }
+
+    // Handle when images are copy/pasted or dragged/dropped into the editor
+    uploadImageHandler = (range, files) => {
+        for (let file of files) {
+            this.upload(file).then((data) => {
+                let delta = new Delta().retain(range.index).delete(range.length).insert({ image: data.url });
+                delete this.imageBytes[data.name]
+                this.quill.updateContents(delta, Quill.sources.USER);
+                this.quill.setSelection(range.index, Quill.sources.SILENT);
+            },
+            (error) => {
+                console.warn(error);
+            });
+        }
+    }
 }


### PR DESCRIPTION
This may resolve #10, but I'm not entirely sure what you had in mind. Regardless, I added the ability to upload images via a Blazor method, or a controller action. After uploading, the images get inserted as an `img` tag with the `src` attribute set to the path of the uploaded image. This is something I need for my project, so I went ahead and fixed it myself. The base64 encoding behavior continues to be enabled by default - this server-side uploading feature must be configured by the user.

In the `MudHtmlEditor.razor.cs` file, I added three new parameters and one new method. Also, I added a `settings` object to group the existing `placeholder` setting with the new ones I added before they get passed via interop to the JS side of the component.

In `MudHtmlEditor.razor.js`, I added `uploadImageHandler` - a custom handler for the (unfortunately undocumented) quill [uploader module](https://github.com/slab/quill/blob/main/packages/quill/src/modules/uploader.ts) - and a supporting `upload` function which does the actual upload to the server.

In the remaining files, I prepared an example controller method and Blazor method that will upload the image to the `wwwroot/images` folder on the server, and return a url like `images/image.png` as the response for the JS to pick back up so it can insert that url as part of the resulting `img` tag.