### PR TITLE
Fix console errors when excluding blotformatter

### DIFF
--- a/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
+++ b/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
@@ -12,18 +12,23 @@ Divider.blotName = 'hr';
 Divider.tagName = 'hr';
 Quill.register(Divider, true);
 
-try {
+if (typeof QuillBlotFormatter !== 'undefined') {
     Quill.register('modules/blotFormatter', QuillBlotFormatter.default);
-} catch { }    
+}
 
 export function createQuillInterop(dotNetRef, editorRef, toolbarRef, placeholder) {
-    var quill = new Quill(editorRef, {
-        modules: {
-            toolbar: {
+    const modulesConfig = {
+        toolbar: {
                 container: toolbarRef
-            },
-            blotFormatter: {}
-        },
+            }
+    };
+    
+    if (typeof QuillBlotFormatter !== 'undefined') {
+    modulesConfig.blotFormatter = {};
+    }
+
+    var quill = new Quill(editorRef, {
+        modulesConfig,
         placeholder: placeholder,
         theme: 'snow'
     });

--- a/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
+++ b/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
@@ -28,7 +28,7 @@ export function createQuillInterop(dotNetRef, editorRef, toolbarRef, placeholder
     }
 
     var quill = new Quill(editorRef, {
-        modulesConfig,
+        modules: modulesConfig,
         placeholder: placeholder,
         theme: 'snow'
     });


### PR DESCRIPTION
When excluding the optional `<script src="_content/Tizzani.MudBlazor.HtmlEditor/quill-blot-formatter.min.js"></script>` console errors start to show up: 
<img width="611" height="825" alt="image" src="https://github.com/user-attachments/assets/ca797114-7e16-4cc1-aac6-9b54fced9d62" />
This fix allows users to exclude the quill blot formatter script if they don't plan on needing using it. 