### PR TITLE
Fix Quill init/disposal race

### DIFF
--- a/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.cs
+++ b/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.cs
@@ -114,14 +114,16 @@ public sealed partial class MudHtmlEditor : IAsyncDisposable
             _dotNetRef = DotNetObjectReference.Create(this);
 
             await using var module = await JS.InvokeAsync<IJSObjectReference>("import", "./_content/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js");
-            _quill = await module.InvokeAsync<IJSObjectReference>("createQuillInterop", _dotNetRef, _editor, _toolbar, Placeholder);
+            var result = await module.InvokeAsync<object?>("createQuillInterop", _dotNetRef, _editor, _toolbar, Placeholder);
 
-            await SetHtml(Html);
-
-            StateHasChanged();
+            if (result is IJSObjectReference quillInterop)
+            {
+                _quill = quillInterop;
+                await SetHtml(Html);
+                StateHasChanged();
+            }
         }
     }
-
 
     [JSInvokable]
     public async void HandleHtmlContentChanged(string html)

--- a/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
+++ b/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
@@ -17,6 +17,10 @@ if (typeof QuillBlotFormatter !== 'undefined') {
 }
 
 export function createQuillInterop(dotNetRef, editorRef, toolbarRef, placeholder) {
+    if (!editorRef || !editorRef.isConnected || !toolbarRef || !toolbarRef.isConnected) {
+        return null;
+    }
+
     const modulesConfig = {
         toolbar: {
                 container: toolbarRef


### PR DESCRIPTION
When quickly initializing/disposing the component a case can occur when the component is rendered, OnAfterRenderAsync is called, the dom element is disposed of on the page (through navigation, user interaction, etc.), createQuillInterop tries to create a new Quill on a disposed element and throws an exception. The fix is to check if the elements are connected before initializing the Quill and return null otherwise. Within OnAfterRenderAsync check if null was returned (meaning the elements are detached) before continuing. 