### PR TITLE
Fix Quill init/disposal race

### DIFF
--- a/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.cs
+++ b/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.cs
@@ -114,14 +114,22 @@ public sealed partial class MudHtmlEditor : IAsyncDisposable
             _dotNetRef = DotNetObjectReference.Create(this);
 
             await using var module = await JS.InvokeAsync<IJSObjectReference>("import", "./_content/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js");
-            _quill = await module.InvokeAsync<IJSObjectReference>("createQuillInterop", _dotNetRef, _editor, _toolbar, Placeholder);
-
-            await SetHtml(Html);
-
-            StateHasChanged();
+            try
+            {
+                _quill = await module.InvokeAsync<IJSObjectReference>("createQuillInterop", _dotNetRef, _editor, _toolbar, Placeholder);
+                await SetHtml(Html);
+                StateHasChanged();
+            }
+            catch (JSException)
+            {
+                // Creation failed due to missing DOM elements
+            }
+            catch (ObjectDisposedException)
+            {
+                // Component disposed before JS interop completed
+            }
         }
     }
-
 
     [JSInvokable]
     public async void HandleHtmlContentChanged(string html)

--- a/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
+++ b/src/Tizzani.MudBlazor.HtmlEditor/MudHtmlEditor.razor.js
@@ -17,6 +17,10 @@ if (typeof QuillBlotFormatter !== 'undefined') {
 }
 
 export function createQuillInterop(dotNetRef, editorRef, toolbarRef, placeholder) {
+    if (!editorRef || !editorRef.isConnected || !toolbarRef || !toolbarRef.isConnected) {
+        throw new Error('DOM elements disconnected.');
+    }
+
     const modulesConfig = {
         toolbar: {
                 container: toolbarRef


### PR DESCRIPTION
Problem: 
A race condition occurs when rapidly initializing/disposing of the htmleditor and some of the methods are called after disposal. For example: OnAfterRenderAsync is called, user interaction removes the dom elements of the component, createQuillInterop is called on null dom elements, exception is thrown.

Fix:
Check if DOM elements are connected in createQuillInterop, otherwise return null. Within OnAfterRenderAsync catch JSException that occurs when dotnet tries creating a IJSObjectReference with a null object. This is really the only way to check for failure without doing another round trip and potentially encountering another race condition.

Problem: 
A race condition occurs after the _quill IJSObjectReference is created but is disposed before SetHtml is called and ObjectDisposedException is thrown.

Fix:
Catch ObjectDisposedException exceptions. 